### PR TITLE
ECOSYS-138 Exploded War support in Payara Micro gradle plugin

### DIFF
--- a/payara-micro-gradle-plugin/build.gradle
+++ b/payara-micro-gradle-plugin/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'maven-publish'
 }
 
 apply plugin: 'java'
-apply plugin: 'maven' 
 apply plugin: "com.gradle.plugin-publish"
 
 group = 'fish.payara.gradle.plugins'
@@ -21,6 +21,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
     compile 'org.apache.commons:commons-lang3:3.9'
+    compile 'commons-io:commons-io:2.6'
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testImplementation 'org.awaitility:awaitility:4.0.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'
@@ -51,6 +52,18 @@ pluginBundle {
             id = 'fish.payara.micro-gradle-plugin'
             displayName = 'Payara Micro Gradle Plugin'
             description = 'Payara Micro gradle plugin incorporates payara-micro with the produced artifact.'
+        }
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            groupId = "fish.payara.gradle.plugins"
+            artifactId = "payara-micro-gradle-plugin"
+            version = "1.0.4-SNAPSHOT"
+
+            from components.java
         }
     }
 }

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/AbstractTask.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/AbstractTask.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.Optional;
+import org.apache.commons.io.FilenameUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
@@ -59,7 +60,7 @@ import org.slf4j.Logger;
 
 public abstract class AbstractTask extends ConventionTask {
 
-    protected Boolean skip;
+    protected boolean skip;
 
     protected Project project;
 
@@ -81,12 +82,8 @@ public abstract class AbstractTask extends ConventionTask {
         return (String) project.getGroup() + ":" + project.getName() + ":" + (String) project.getVersion();
     }
 
-    public Boolean getSkip() {
+    public boolean isSkip() {
         return skip;
-    }
-
-    public void setSkip(Boolean skip) {
-        this.skip = skip;
     }
 
     protected Optional<String> getPayaraMicroPath(String version) {
@@ -102,12 +99,18 @@ public abstract class AbstractTask extends ConventionTask {
                 .map(File::getAbsolutePath);
     }
 
-    protected File getWar() {
-        return ((War) project.getTasks().getByName(WarPlugin.WAR_TASK_NAME)).getArchivePath();
+    protected War getWar() {
+        return (War) project.getTasks().getByName(WarPlugin.WAR_TASK_NAME);
     }
 
     protected String getWarPath() {
-        return getWar().getAbsolutePath();
+        return getWar().getArchivePath().getAbsolutePath();
+    }
+
+    protected String getExplodedWarPath() {
+        return getWar().getArchivePath().getParent() 
+                + File.separator 
+                + FilenameUtils.getBaseName(getWar().getArchiveName());
     }
 
     protected File getUberJar() {
@@ -115,10 +118,10 @@ public abstract class AbstractTask extends ConventionTask {
     }
 
     protected String getUberJarPath() {
-        return getWar().getAbsolutePath().replace(
-                "." + WAR_EXTENSION,
-                "-" + MICROBUNDLE_EXTENSION + "." + JAR_EXTENSION
-        );
+        return getWar()
+                .getArchivePath()
+                .getAbsolutePath()
+                .replace("." + WAR_EXTENSION, "-" + MICROBUNDLE_EXTENSION + "." + JAR_EXTENSION);
     }
 
     protected void copy(InputStream in, OutputStream out) throws IOException {

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/BundleTask.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/BundleTask.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -62,7 +62,7 @@ public class BundleTask extends AbstractTask {
 
     @Override
     public void configure(PayaraMicroExtension extension) {
-        this.skip = extension.getSkip();
+        this.skip = extension.isSkip();
         this.javaPath = extension.getJavaPath();
         this.payaraVersion = extension.getPayaraVersion();
     }

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/ExplodeWarTask.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/ExplodeWarTask.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,48 +38,31 @@
  */
 package fish.payara.gradle.plugins.micro;
 
-import org.gradle.api.Project;
-import org.junit.jupiter.api.Test;
+import java.io.File;
+import java.nio.file.Path;
+import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.Sync;
 
-public class StartStopLifecycleTest extends BaseTest {
+public class ExplodeWarTask extends Sync {
 
-    @Test
-    public void warTest() throws Exception {
+    public static final String EXPLODE_TASK_NAME = "warExplode";
 
-        Project project = buildProject();
-        PayaraMicroExtension extension = buildExtension(project);
+    public static final String EXPLODE_TASK_DESCRIPTION = "Extact WAR file into the build folder.";
 
-        bootstrapMicro(project, extension);
+    private File explodedWarDirectory;
+
+    public void setWarFile(Path warFile) {
+        from(getProject().zipTree(warFile));
     }
 
-    @Test
-    public void customMicroVersionTest() throws Exception {
-
-        Project project = buildProject();
-        PayaraMicroExtension extension = buildExtension(project);
-        extension.setPayaraVersion("5.181");
-
-        bootstrapMicro(project, extension);
+    public void setExplodedWarDirectory(Path explodedWarDirectory) {
+        this.explodedWarDirectory = explodedWarDirectory.toFile();
+        into(explodedWarDirectory);
     }
 
-    @Test
-    public void uberJarTest() throws Exception {
-
-        Project project = buildProject();
-        PayaraMicroExtension extension = buildExtension(project);
-        extension.setUseUberJar(true);
-
-        bundleMicro(project, extension);
-        bootstrapMicro(project, extension);
+    @OutputDirectory
+    public File getExplodedWarDirectory() {
+        return explodedWarDirectory;
     }
 
-    @Test
-    public void explodedWarTest() throws Exception {
-
-        Project project = buildProject();
-        PayaraMicroExtension extension = buildExtension(project);
-        extension.setExploded(true);
-
-        bootstrapMicro(project, extension);
-    }
 }

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
@@ -97,7 +97,7 @@ public class PayaraMicroExtension {
     }
 
     public boolean isSkip() {
-        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".skip", String.valueOf(skip)));
+        return Boolean.valueOf(getValue("skip", skip));
     }
 
     public void setSkip(boolean skip) {
@@ -105,7 +105,7 @@ public class PayaraMicroExtension {
     }
 
     public boolean isImmediateExit() {
-        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".immediateExit", String.valueOf(immediateExit)));
+        return Boolean.valueOf(getValue("immediateExit", immediateExit));
     }
 
     public void setImmediateExit(boolean immediateExit) {
@@ -113,7 +113,7 @@ public class PayaraMicroExtension {
     }
 
     public boolean isDaemon() {
-        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".daemon", String.valueOf(daemon)));
+        return Boolean.valueOf(getValue("daemon", daemon));
     }
 
     public void setDaemon(boolean daemon) {
@@ -121,7 +121,7 @@ public class PayaraMicroExtension {
     }
 
     public String getJavaPath() {
-        return System.getProperty(PLUGIN_ID + ".javaPath", javaPath);
+        return getValue("javaPath", javaPath);
     }
 
     public void setJavaPath(String javaPath) {
@@ -129,7 +129,7 @@ public class PayaraMicroExtension {
     }
 
     public boolean isUseUberJar() {
-        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".useUberJar", String.valueOf(useUberJar)));
+        return Boolean.valueOf(getValue("useUberJar", useUberJar));
     }
 
     public void setUseUberJar(boolean useUberJar) {
@@ -137,7 +137,7 @@ public class PayaraMicroExtension {
     }
 
     public boolean isDeployWar() {
-        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".deployWar", String.valueOf(deployWar)));
+        return Boolean.valueOf(getValue("deployWar", deployWar));
     }
 
     public void setDeployWar(boolean deployWar) {
@@ -145,7 +145,7 @@ public class PayaraMicroExtension {
     }
 
     public boolean isExploded() {
-        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".exploded", String.valueOf(exploded)));
+        return Boolean.valueOf(getValue("exploded", exploded));
     }
 
     public void setExploded(boolean exploded) {
@@ -153,7 +153,7 @@ public class PayaraMicroExtension {
     }
 
     public String getDebug() {
-        return System.getProperty(PLUGIN_ID + ".debug", debug);
+        return getValue("debug", debug);
     }
 
     public void setDebug(String debug) {
@@ -161,7 +161,7 @@ public class PayaraMicroExtension {
     }
 
     public String getPayaraMicroAbsolutePath() {
-        return System.getProperty(PLUGIN_ID + ".payaraMicroAbsolutePath", payaraMicroAbsolutePath);
+        return getValue("payaraMicroAbsolutePath", payaraMicroAbsolutePath);
     }
 
     public void setPayaraMicroAbsolutePath(String payaraMicroAbsolutePath) {
@@ -169,7 +169,7 @@ public class PayaraMicroExtension {
     }
 
     public String getPayaraVersion() {
-        return System.getProperty(PLUGIN_ID + ".payaraVersion", payaraVersion);
+        return getValue("payaraVersion", payaraVersion);
     }
 
     public void setPayaraVersion(String payaraVersion) {
@@ -193,11 +193,15 @@ public class PayaraMicroExtension {
     }
 
     public String getProcessId() {
-        return System.getProperty(PLUGIN_ID + ".processId", processId);
+        return getValue("processId", processId);
     }
 
     public void setProcessId(String processId) {
         this.processId = processId;
+    }
+
+    private <T> String getValue(String key, T defaultValue) {
+        return System.getProperty(PLUGIN_ID + "." + key, String.valueOf(defaultValue));
     }
 
 }

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -39,22 +39,36 @@
 package fish.payara.gradle.plugins.micro;
 
 import static fish.payara.gradle.plugins.micro.Configuration.DEFAULT_MICRO_VERSION;
+import static fish.payara.gradle.plugins.micro.PayaraMicroPlugin.PLUGIN_ID;
 import java.util.Map;
 import org.gradle.api.Project;
 
 public class PayaraMicroExtension {
 
-    private Boolean skip = false;
+    private boolean skip;
 
-    private Boolean immediateExit = true;
+    private boolean immediateExit = true;
 
-    private Boolean daemon = false;
+    private boolean daemon;
 
     private String javaPath = "java";
 
-    private Boolean useUberJar = false;
+    private boolean useUberJar;
 
-    private Boolean deployWar = false;
+    private boolean deployWar;
+
+    /**
+     * Use exploded artifact for deployment.
+     */
+    private boolean exploded;
+
+    /**
+     * Attach a debugger. If set to "true", the process will suspend and wait
+     * for a debugger to attach on port 5005. If set to other value, will be
+     * appended to the argLine, allowing you to configure custom debug options.
+     *
+     */
+    private String debug;
 
     private String payaraMicroAbsolutePath;
 
@@ -78,56 +92,76 @@ public class PayaraMicroExtension {
         this.project = project;
     }
 
-    public Boolean getSkip() {
-        return skip;
+    public Project getProject() {
+        return project;
     }
 
-    public void setSkip(Boolean skip) {
+    public boolean isSkip() {
+        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".skip", String.valueOf(skip)));
+    }
+
+    public void setSkip(boolean skip) {
         this.skip = skip;
     }
 
-    public Boolean getImmediateExit() {
-        return immediateExit;
+    public boolean isImmediateExit() {
+        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".immediateExit", String.valueOf(immediateExit)));
     }
 
-    public void setImmediateExit(Boolean immediateExit) {
+    public void setImmediateExit(boolean immediateExit) {
         this.immediateExit = immediateExit;
     }
 
-    public Boolean getDaemon() {
-        return daemon;
+    public boolean isDaemon() {
+        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".daemon", String.valueOf(daemon)));
     }
 
-    public void setDaemon(Boolean daemon) {
+    public void setDaemon(boolean daemon) {
         this.daemon = daemon;
     }
 
     public String getJavaPath() {
-        return javaPath;
+        return System.getProperty(PLUGIN_ID + ".javaPath", javaPath);
     }
 
     public void setJavaPath(String javaPath) {
         this.javaPath = javaPath;
     }
 
-    public Boolean getUseUberJar() {
-        return useUberJar;
+    public boolean isUseUberJar() {
+        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".useUberJar", String.valueOf(useUberJar)));
     }
 
-    public void setUseUberJar(Boolean useUberJar) {
+    public void setUseUberJar(boolean useUberJar) {
         this.useUberJar = useUberJar;
     }
 
-    public Boolean getDeployWar() {
-        return deployWar;
+    public boolean isDeployWar() {
+        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".deployWar", String.valueOf(deployWar)));
     }
 
-    public void setDeployWar(Boolean deployWar) {
+    public void setDeployWar(boolean deployWar) {
         this.deployWar = deployWar;
     }
 
+    public boolean isExploded() {
+        return Boolean.valueOf(System.getProperty(PLUGIN_ID + ".exploded", String.valueOf(exploded)));
+    }
+
+    public void setExploded(boolean exploded) {
+        this.exploded = exploded;
+    }
+
+    public String getDebug() {
+        return System.getProperty(PLUGIN_ID + ".debug", debug);
+    }
+
+    public void setDebug(String debug) {
+        this.debug = debug;
+    }
+
     public String getPayaraMicroAbsolutePath() {
-        return payaraMicroAbsolutePath;
+        return System.getProperty(PLUGIN_ID + ".payaraMicroAbsolutePath", payaraMicroAbsolutePath);
     }
 
     public void setPayaraMicroAbsolutePath(String payaraMicroAbsolutePath) {
@@ -135,7 +169,7 @@ public class PayaraMicroExtension {
     }
 
     public String getPayaraVersion() {
-        return payaraVersion;
+        return System.getProperty(PLUGIN_ID + ".payaraVersion", payaraVersion);
     }
 
     public void setPayaraVersion(String payaraVersion) {
@@ -159,7 +193,7 @@ public class PayaraMicroExtension {
     }
 
     public String getProcessId() {
-        return processId;
+        return System.getProperty(PLUGIN_ID + ".processId", processId);
     }
 
     public void setProcessId(String processId) {

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
@@ -201,7 +201,11 @@ public class PayaraMicroExtension {
     }
 
     private <T> String getValue(String key, T defaultValue) {
-        return System.getProperty(PLUGIN_ID + "." + key, String.valueOf(defaultValue));
+        if (defaultValue != null) {
+            return System.getProperty(PLUGIN_ID + "." + key, String.valueOf(defaultValue));
+        } else {
+            return System.getProperty(PLUGIN_ID + "." + key);
+        }
     }
 
 }

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroPlugin.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroPlugin.java
@@ -54,7 +54,7 @@ import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.MavenPlugin;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.bundling.War;
-
+  
 public class PayaraMicroPlugin implements Plugin<Project> {
 
     public static final String PLUGIN_ID = "payaraMicro";
@@ -70,11 +70,13 @@ public class PayaraMicroPlugin implements Plugin<Project> {
         StartTask startTask = createMicroStartTask();
         StopTask stopTask = createMicroStopTask();
         BundleTask bundleTask = createMicroBundleTask();
+        ReloadTask reloadTask = createMicroReloadTask();
         PayaraMicroExtension extension = createExtension();
         project.afterEvaluate(prj -> {
             startTask.configure(extension);
             stopTask.configure(extension);
             bundleTask.configure(extension);
+            reloadTask.configure(extension);
             createExplodeWarTask();
         });
     }
@@ -100,6 +102,10 @@ public class PayaraMicroPlugin implements Plugin<Project> {
 
     private StopTask createMicroStopTask() {
         return createTask(STOP_TASK_NAME, STOP_TASK_DESCRIPTION, StopTask.class);
+    }
+
+    private ReloadTask createMicroReloadTask() {
+        return createTask(ReloadTask.RELOAD_TASK_NAME, ReloadTask.RELOAD_TASK_DESCRIPTION, ReloadTask.class);
     }
 
     private ExplodeWarTask createExplodeWarTask() {

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/ReloadTask.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/ReloadTask.java
@@ -1,0 +1,92 @@
+/*
+ *
+ * Copyright (c) 2020 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.gradle.plugins.micro;
+
+import java.io.File;
+import java.io.IOException;
+import org.gradle.api.tasks.TaskAction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReloadTask extends AbstractTask {
+
+    public static final String RELOAD_TASK_NAME = "microReload";
+
+    public static final String RELOAD_TASK_DESCRIPTION = "Redeploys the exploded WAR file.";
+
+    private static final Logger LOG = LoggerFactory.getLogger(ReloadTask.class);
+
+    private static final String RELOAD_FILE = ".reload";
+
+    @Override
+    public void configure(PayaraMicroExtension extension) {
+        this.skip = extension.isSkip();
+    }
+
+    @TaskAction
+    public void onStop() {
+
+        if (skip) {
+            getLog().info("Reload task execution is skipped");
+            return;
+        }
+
+        File explodedDir = new File(getExplodedWarPath());
+        if (!explodedDir.exists()) {
+            throw new IllegalStateException(String.format("explodedDir[%s] not found", explodedDir.toString()));
+        }
+        File reloadFile = new File(explodedDir, RELOAD_FILE);
+        if (reloadFile.exists()) {
+            reloadFile.setLastModified(System.currentTimeMillis());
+        } else {
+            try {
+                reloadFile.createNewFile();
+            } catch (IOException ex) {
+                throw new IllegalStateException("Unable to create .reload file " + ex.toString());
+            }
+        }
+
+    }
+
+    @Override
+    public Logger getLog() {
+        return LOG;
+    }
+
+}

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/StopTask.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/StopTask.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -54,18 +54,18 @@ public class StopTask extends AbstractTask {
 
     public static final String STOP_TASK_NAME = "microStop";
 
-    public static final String STOP_TASK_DESCRIPTION = "Assembles the JavaEE app into a war and deploys it to payara-micro.";
+    public static final String STOP_TASK_DESCRIPTION = "Stops Payara Micro with the specified configuration.";
 
     private static final Logger LOG = LoggerFactory.getLogger(StopTask.class);
 
     private String processId;
 
-    private Boolean useUberJar;
+    private boolean useUberJar;
 
     @Override
     public void configure(PayaraMicroExtension extension) {
-        this.skip = extension.getSkip();
-        this.useUberJar = extension.getUseUberJar();
+        this.skip = extension.isSkip();
+        this.useUberJar = extension.isUseUberJar();
         this.processId = extension.getProcessId();
     }
 
@@ -163,7 +163,7 @@ public class StopTask extends AbstractTask {
         return processId;
     }
 
-    public Boolean getUseUberJar() {
+    public boolean isUseUberJar() {
         return useUberJar;
     }
 

--- a/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/BaseTest.java
+++ b/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/BaseTest.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) [2018-2019] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,13 +38,14 @@
  */
 package fish.payara.gradle.plugins.micro;
 
-import java.util.concurrent.TimeUnit;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static fish.payara.gradle.plugins.micro.BundleTask.BUNDLE_TASK_NAME;
+import static fish.payara.gradle.plugins.micro.StartTask.START_TASK_NAME;
+import static fish.payara.gradle.plugins.micro.StopTask.STOP_TASK_NAME;
 import org.awaitility.Awaitility;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.internal.artifacts.dsl.DefaultRepositoryHandler;
-import org.gradle.api.plugins.WarPlugin;
+import static org.gradle.api.plugins.WarPlugin.WAR_TASK_NAME;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.testfixtures.ProjectBuilder;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -84,31 +85,31 @@ public abstract class BaseTest {
     }
 
     protected void bundleMicro(Project project, PayaraMicroExtension extension) {
-        Task task = project.getTasks().getByName("microBundle");
+        Task task = project.getTasks().getByName(BUNDLE_TASK_NAME);
         assertTrue(task instanceof BundleTask);
         BundleTask bundleTask = (BundleTask) task;
 
         bundleTask.configure(extension);
 
-        War war = ((War) project.getTasks().getByName(WarPlugin.WAR_TASK_NAME));
+        War war = ((War) project.getTasks().getByName(WAR_TASK_NAME));
         war.execute();
         assertTrue(war.getArchivePath().exists());
 
         bundleTask.execute();
         assertNotNull(bundleTask.getPayaraMicroPath(extension.getPayaraVersion()));
-        assertTrue(bundleTask.getWar().exists());
+        assertTrue(bundleTask.getWar().getArchivePath().exists());
         assertTrue(bundleTask.getUberJar().exists());
     }
 
     protected void bootstrapMicro(Project project, PayaraMicroExtension extension) {
-        Task task = project.getTasks().getByName("microStart");
+        Task task = project.getTasks().getByName(START_TASK_NAME);
         assertTrue(task instanceof StartTask);
         StartTask startTask = (StartTask) task;
 
         startTask.configure(extension);
         assertNotNull(startTask.decideOnWhichMicroToUse());
 
-        task = project.getTasks().getByName("microStop");
+        task = project.getTasks().getByName(STOP_TASK_NAME);
         assertTrue(task instanceof StopTask);
         StopTask stopTask = (StopTask) task;
 


### PR DESCRIPTION
# Description
This is a feature introducing the new `exploded` & `debug` option and `microReload` task.

New extension params added:
**exploded:** Use exploded artifact for deployment.
**debug:** Attach a debugger. If set to "true", the process will suspend and wait for a debugger to attach on port 5005. If set to other value, will be appended to the argLine, allowing you to configure custom debug options.
Extension param value can be overridden from command using system properties e.g 
`gradle -DpayaraMicro.exploded=true microStart`
https://github.com/payara/ecosystem-gradle/blob/bf4b28ffa1172f7bd1646942e44248ffcad30535/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java#L60-L71

**Reload task:** Payara Micro reload task in gradle plugin to redeploy the exploded WAR file. e.g
`gradle microReload`
https://github.com/payara/ecosystem-gradle/blob/bf4b28ffa1172f7bd1646942e44248ffcad30535/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/ReloadTask.java#L47-L51

## Testing
Unit test added https://github.com/payara/ecosystem-gradle/blob/bf4b28ffa1172f7bd1646942e44248ffcad30535/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/StartStopLifecycleTest.java#L77-L84

