### PR TITLE
FISH-9510 Payara Micro Gradle plugin auto select default latest version Payara Micro based on Jakarta EE API version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
                     sh '''
                     ls -lrt
                     cd payara-micro-gradle-plugin
-                    gradle clean build -x check         
+                    gradle clean build
                     '''
                     echo '*#*#*#*#*#*#*#*#*#*#*#*#    Built SRC   *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#'
                 }

--- a/payara-micro-gradle-plugin/build.gradle
+++ b/payara-micro-gradle-plugin/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'fish.payara.gradle.plugins'
-version = '2.0.1'
+version = '2.0.2-SNAPSHOT'
 
 sourceCompatibility = '1.8'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
@@ -19,7 +19,9 @@ repositories {
 dependencies {
     api gradleApi()
     api localGroovy()
+    implementation 'org.jdom:jdom2:2.0.6'
     implementation 'commons-io:commons-io:2.11.0'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.apache.commons:commons-lang3:3.12.0'
     implementation 'org.apache.commons:commons-text:1.10.0'
     testImplementation gradleTestKit()

--- a/payara-micro-gradle-plugin/gradle.properties
+++ b/payara-micro-gradle-plugin/gradle.properties
@@ -1,0 +1,2 @@
+action.custom-1=publishToMavenLocal
+action.custom-1.args=--configure-on-demand -w -x check publishToMavenLocal

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/Configuration.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/Configuration.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) [2018-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2018-2024] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -44,7 +44,7 @@ public interface Configuration {
     String MICRO_THREAD_NAME = "PayaraMicroThread";
     String MICRO_READY_MESSAGE = "ready in";
 
-    String DEFAULT_MICRO_VERSION = "6.2023.1";
+    String DEFAULT_MICRO_VERSION = "6.2024.10";
 
     String JAR_EXTENSION = "jar";
     String WAR_EXTENSION = "war";

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
@@ -73,7 +73,7 @@ public class PayaraMicroExtension {
 
     private String payaraMicroAbsolutePath;
 
-    private String payaraVersion = DEFAULT_MICRO_VERSION;
+    private String payaraVersion;
     
     private String contextRoot;
     
@@ -180,6 +180,9 @@ public class PayaraMicroExtension {
     }
 
     public String getPayaraVersion() {
+        if(payaraVersion != null) {
+            return payaraVersion;
+        }
         PayaraMicroVersionSelector selector = new PayaraMicroVersionSelector(project);
         String version = null;
         try {

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroExtension.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018-2020 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -41,6 +41,7 @@ package fish.payara.gradle.plugins.micro;
 import static fish.payara.gradle.plugins.micro.Configuration.DEFAULT_MICRO_VERSION;
 import static fish.payara.gradle.plugins.micro.PayaraMicroPlugin.PLUGIN_ID;
 import java.util.Map;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 
 public class PayaraMicroExtension {
@@ -179,7 +180,17 @@ public class PayaraMicroExtension {
     }
 
     public String getPayaraVersion() {
-        return getValue("payaraVersion", payaraVersion);
+        PayaraMicroVersionSelector selector = new PayaraMicroVersionSelector(project);
+        String version = null;
+        try {
+            version = selector.fetchPayaraVersion();
+        } catch (GradleException ex) {
+            project.getLogger().error("Unable to fetch the version from Maven Central " + ex.toString());
+        }
+        if (version == null) {
+            version = DEFAULT_MICRO_VERSION;
+        }
+        return getValue("payaraVersion", version);
     }
 
     public void setPayaraVersion(String payaraVersion) {

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroVersionSelector.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroVersionSelector.java
@@ -128,7 +128,7 @@ public class PayaraMicroVersionSelector {
         }
     }
 
-    private String getPayaraMicroVersion(int jakartaMajorVersion) throws GradleException {
+    public static String getPayaraMicroVersion(int jakartaMajorVersion) throws GradleException {
         return fetchPayaraMicroVersion(version -> version.startsWith(JAKARTA_TO_PAYARA_MAP.get(jakartaMajorVersion)));
     }
 
@@ -136,7 +136,7 @@ public class PayaraMicroVersionSelector {
         return fetchPayaraMicroVersion(version -> true);
     }
 
-    private String fetchPayaraMicroVersion(Predicate<String> versionPredicate) throws GradleException {
+    private static String fetchPayaraMicroVersion(Predicate<String> versionPredicate) throws GradleException {
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
             HttpGet httpGet = new HttpGet(MAVEN_METADATA_URL);
             try (CloseableHttpResponse response = httpClient.execute(httpGet)) {

--- a/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroVersionSelector.java
+++ b/payara-micro-gradle-plugin/src/main/java/fish/payara/gradle/plugins/micro/PayaraMicroVersionSelector.java
@@ -1,0 +1,169 @@
+/*
+ *
+ * Copyright (c) [2024] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package fish.payara.gradle.plugins.micro;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.gradle.api.GradleException;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.input.SAXBuilder;
+
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.gradle.api.artifacts.DependencySet;
+
+public class PayaraMicroVersionSelector {
+
+    private static final String MAVEN_METADATA_URL = "https://repo1.maven.org/maven2/fish/payara/extras/payara-micro/maven-metadata.xml";
+    private static final String GROUP_ID_JAKARTA = "jakarta.platform";
+    private static final String GROUP_ID_JAVAX = "javax";
+    private static final String ARTIFACT_ID_JAVAEE_WEB_API = "javaee-web-api";
+    private static final String ARTIFACT_ID_JAVAEE_API = "javaee-api";
+
+    private static final Map<Integer, String> JAKARTA_TO_PAYARA_MAP = new HashMap<>();
+    private final Project project;
+
+    public PayaraMicroVersionSelector(Project project) {
+        this.project = project;
+    }
+
+    static {
+        JAKARTA_TO_PAYARA_MAP.put(11, "7."); // Jakarta EE 11 -> Payara Micro 7.x
+        JAKARTA_TO_PAYARA_MAP.put(10, "6."); // Jakarta EE 10 -> Payara Micro 6.x
+        JAKARTA_TO_PAYARA_MAP.put(9, "6.");  // Jakarta EE 9 -> Payara Micro 6.x
+        JAKARTA_TO_PAYARA_MAP.put(8, "5.");  // Jakarta EE 8 -> Payara Micro 5.x
+    }
+
+    public String fetchPayaraVersion() throws GradleException {
+        String jakartaVersion = getJakartaVersion();
+        String payaraMicroVersion = null;
+        if (jakartaVersion != null) {
+            int jakartaMajorVersion = getJakartaMajorVersion(jakartaVersion);
+            if (jakartaMajorVersion != -1) {
+                payaraMicroVersion = getPayaraMicroVersion(jakartaMajorVersion);
+                if (payaraMicroVersion != null) {
+                    project.getLogger().info("Selected Payara Micro version '" + payaraMicroVersion + "' for Jakarta EE version '" + jakartaVersion + "'.");
+                } else {
+                    project.getLogger().warn("Could not determine the appropriate Payara Micro version.");
+                }
+            } else {
+                project.getLogger().warn("Invalid Jakarta EE version: " + jakartaVersion);
+            }
+        } else {
+            payaraMicroVersion = getLatestPayaraMicroVersion();
+            if (payaraMicroVersion != null) {
+                project.getLogger().info("No Jakarta EE dependency found. Using latest Payara Micro version: " + payaraMicroVersion);
+            } else {
+                project.getLogger().warn("Could not fetch the latest Payara Micro version.");
+            }
+        }
+        return payaraMicroVersion;
+    }
+
+    private String getJakartaVersion() {
+       DependencySet dependencies = project.getConfigurations().getByName("compileClasspath").getAllDependencies();
+        for (Dependency dependency : dependencies) {
+            if (GROUP_ID_JAKARTA.equals(dependency.getGroup())) {
+                return dependency.getVersion();
+            }
+            if (GROUP_ID_JAVAX.equals(dependency.getGroup())
+                    && (ARTIFACT_ID_JAVAEE_API.equals(dependency.getName()) || ARTIFACT_ID_JAVAEE_WEB_API.equals(dependency.getName()))) {
+                return dependency.getVersion();
+            }
+        }
+        return null;
+    }
+
+    private int getJakartaMajorVersion(String jakartaVersion) {
+        try {
+            return Integer.parseInt(jakartaVersion.split("\\.")[0]);
+        } catch (NumberFormatException e) {
+            return -1;
+        }
+    }
+
+    private String getPayaraMicroVersion(int jakartaMajorVersion) throws GradleException {
+        return fetchPayaraMicroVersion(version -> version.startsWith(JAKARTA_TO_PAYARA_MAP.get(jakartaMajorVersion)));
+    }
+
+    private String getLatestPayaraMicroVersion() throws GradleException {
+        return fetchPayaraMicroVersion(version -> true);
+    }
+
+    private String fetchPayaraMicroVersion(Predicate<String> versionPredicate) throws GradleException {
+        try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+            HttpGet httpGet = new HttpGet(MAVEN_METADATA_URL);
+            try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+                HttpEntity entity = response.getEntity();
+
+                if (entity != null) {
+                    String xmlContent = EntityUtils.toString(entity);
+                    SAXBuilder saxBuilder = new SAXBuilder();
+                    Document document = saxBuilder.build(new StringReader(xmlContent));
+                    Element rootElement = document.getRootElement();
+                    Element versionsElement = rootElement.getChild("versioning").getChild("versions");
+
+                    if (versionsElement != null) {
+                        List<Element> versionElements = versionsElement.getChildren("version");
+
+                        for (int i = versionElements.size() - 1; i >= 0; i--) {
+                            String version = versionElements.get(i).getText();
+                            if (versionPredicate.test(version)) {
+                                return version;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new GradleException("Error fetching Payara Micro version", e);
+        }
+        return null;
+    }
+}

--- a/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/JakartaEEVersionSelector.java
+++ b/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/JakartaEEVersionSelector.java
@@ -1,6 +1,6 @@
 /*
  *
- * Copyright (c) 2018 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -38,18 +38,33 @@
  */
 package fish.payara.gradle.plugins.micro;
 
-import org.junit.jupiter.api.Test;
+public class JakartaEEVersionSelector {
 
-public class BundleLifecycleTest extends BaseTest {
+    public static int getMajorJakartaEEVersion() {
+        int jdkVersion = getCurrentJDKVersion();
+        switch (jdkVersion) {
+            case 21:
+                return 11; // Select 11 for JDK 21
+            case 17:
+                return 10; // Select 10 for JDK 17
+            case 11:
+                return 8;  // Select 8 for JDK 11
+            default:
+                return 8;
+        }
+    }
 
-    @Test
-    public void uberJarBundleTest() throws Exception {
+    private static int getCurrentJDKVersion() {
+        String version = System.getProperty("java.version");
+        String[] versionParts = version.split("\\.");
+        int majorVersion;
 
-        buildProject();
-        PayaraMicroExtension extension = buildExtension();
-        int jakataEEVersion = JakartaEEVersionSelector.getMajorJakartaEEVersion();
-        String payaraVersion = PayaraMicroVersionSelector.getPayaraMicroVersion(jakataEEVersion);
-        extension.setPayaraVersion(payaraVersion);
-        bundleMicro();
+        if (versionParts[0].equals("1")) {
+            majorVersion = Integer.parseInt(versionParts[1]); // For versions like 1.8
+        } else {
+            majorVersion = Integer.parseInt(versionParts[0]); // For versions like 9, 10, 11
+        }
+
+        return majorVersion;
     }
 }

--- a/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/StartStopLifecycleTest.java
+++ b/payara-micro-gradle-plugin/src/test/java/fish/payara/gradle/plugins/micro/StartStopLifecycleTest.java
@@ -46,7 +46,12 @@ public class StartStopLifecycleTest extends BaseTest {
     public void warTest() throws Exception {
 
         buildProject();
-        buildExtension().setDeployWar(true);
+        
+        PayaraMicroExtension extension = buildExtension();
+        int jakataEEVersion = JakartaEEVersionSelector.getMajorJakartaEEVersion();
+        String payaraVersion = PayaraMicroVersionSelector.getPayaraMicroVersion(jakataEEVersion);
+        extension.setPayaraVersion(payaraVersion);
+        extension.setDeployWar(true);
 
         createWar();
         bootstrapMicro();
@@ -66,7 +71,11 @@ public class StartStopLifecycleTest extends BaseTest {
     public void uberJarTest() throws Exception {
 
         buildProject();
-        buildExtension().setUseUberJar(true);
+        PayaraMicroExtension extension = buildExtension();
+        int jakataEEVersion = JakartaEEVersionSelector.getMajorJakartaEEVersion();
+        String payaraVersion = PayaraMicroVersionSelector.getPayaraMicroVersion(jakataEEVersion);
+        extension.setPayaraVersion(payaraVersion);
+        extension.setUseUberJar(true);
 
         bundleMicro();
         bootstrapMicro();
@@ -74,9 +83,11 @@ public class StartStopLifecycleTest extends BaseTest {
 
     @Test
     public void explodedWarTest() throws Exception {
-
         buildProject();
         PayaraMicroExtension extension = buildExtension();
+        int jakataEEVersion = JakartaEEVersionSelector.getMajorJakartaEEVersion();
+        String payaraVersion = PayaraMicroVersionSelector.getPayaraMicroVersion(jakataEEVersion);
+        extension.setPayaraVersion(payaraVersion);
         extension.setDeployWar(true);
         extension.setExploded(true);
 


### PR DESCRIPTION
To test the **FISH-9510** Payara Micro Gradle plugin PR, which auto-selects the latest default Payara Micro version based on the Jakarta EE API version, you can follow these steps:

## Test the Plugin Locally

### Step 1: Publish the Plugin to Local Maven Repository
Run the following command to publish the plugin to your local Maven repository:

```bash
gradle publishToMavenLocal
   ```

### Step 2: Update Your Sample Application
1. **Remove the Existing Plugin ID**  
   Open the `build.gradle` file of your sample application and remove the Payara Micro Gradle Plugin from the `plugins` block:

   ```gradle
   plugins {
       id 'java'
       id 'war'
       // Remove the following line
       // id 'fish.payara.micro-gradle-plugin' version '<published-version>'
   }
   ```

2. **Update Local Coordinates**  
   Update the plugin configuration to use the local Maven repository version by adjusting the `buildscript` and applying the plugin:

   ```gradle
   buildscript {
       repositories {
           mavenLocal()   // Ensures the local Maven repository is checked first
           mavenCentral()
       }
       dependencies {
           classpath 'fish.payara.gradle.plugins:payara-micro-gradle-plugin:<published-version>'
       }
   }

   plugins {
       id 'java'
       id 'war'
   }
   apply plugin: 'fish.payara.micro-gradle-plugin'
   ```
   
## Test Cases
   
### **Case 1: Jakarta EE 10 Application**

1. Go to [https://aidemo.start.payara.fish/](https://aidemo.start.payara.fish/).
2. Create a **Gradle** + **Payara Micro Application** with **Jakarta EE 10**.
3. In the `build.gradle` file, **remove the Payara version** declaration.
4. Run the application.  
   **Expected Outcome**: The Gradle plugin should automatically fetch and start the latest Payara Micro version compatible with Jakarta EE 10.
   
### **Case 2: Jakarta EE 8 Application**

1. Go to [https://aidemo.start.payara.fish/](https://aidemo.start.payara.fish/).
2. Create a **Gradle** + **Payara Micro Application** with **Jakarta EE 8**.
3. In the `build.gradle` file, **remove the Payara version** declaration.
4. Run the application.  
   **Expected Outcome**: The Gradle plugin should automatically fetch and start the latest Payara Micro 5 version compatible with Jakarta EE 8.
